### PR TITLE
Fix: Resolve BDD DuplicateStepDefinitionExceptions and CucumberBacken…

### DIFF
--- a/src/test/java/dev/paul/cartlink/bdd/steps/AnalyticsStepDefinitions.java
+++ b/src/test/java/dev/paul/cartlink/bdd/steps/AnalyticsStepDefinitions.java
@@ -39,9 +39,9 @@ public class AnalyticsStepDefinitions {
     @Autowired private ObjectMapper objectMapper;
     @Autowired private LinkAnalyticsRepository linkAnalyticsRepository;
     @Autowired private ScenarioContext scenarioContext;
+    @Autowired private CommonStepDefinitions commonStepDefinitions; // Ensure common steps can be called if needed, or rely on Cucumber glue
 
 
-    private ResponseEntity<String> latestResponse;
     // private Map<String, String> sharedData = new HashMap<>(); // Will use scenarioContext instead
 
     @Before
@@ -96,32 +96,15 @@ public class AnalyticsStepDefinitions {
     }
 
 
-    @When("a GET request is made to {string}")
-    public void a_get_request_is_made_to(String path) {
-        HttpEntity<Void> entity = new HttpEntity<>(new HttpHeaders()); // No auth needed as per controller
-        String resolvedPath = resolvePlaceholders(path);
-        String baseUrl = scenarioContext.getString("apiBaseUrl");
-        latestResponse = restTemplate.exchange(baseUrl + resolvedPath, HttpMethod.GET, entity, String.class);
-        logger.info("GET to {}: Status {}, Body {}", resolvedPath, latestResponse.getStatusCodeValue(), latestResponse.getBody());
-    }
-
-    @When("a POST request is made to {string} with the following body:")
-    public void a_post_request_is_made_to_with_body(String path, String requestBody) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        // No auth needed as per controller
-        String resolvedPath = resolvePlaceholders(path);
-        String resolvedBody = resolvePlaceholders(requestBody);
-        String baseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpEntity<String> entity = new HttpEntity<>(resolvedBody, headers);
-        latestResponse = restTemplate.postForEntity(baseUrl + resolvedPath, entity, String.class);
-        logger.info("POST to {}: Status {}, Body {}", resolvedPath, latestResponse.getStatusCodeValue(), latestResponse.getBody());
-    }
+    // Removed duplicate GET request method, will use the one from CommonStepDefinitions
+    // Removed duplicate POST request method, will use the one from CommonStepDefinitions
 
     // --- Then Steps ---
     @Then("the response body should contain a {string} with number value {string}")
     public void the_response_body_should_contain_with_number_value(String jsonPath, String expectedValueKey) {
+        @SuppressWarnings("unchecked")
+        ResponseEntity<String> latestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
+        assertThat(latestResponse).isNotNull();
         assertThat(latestResponse.getBody()).isNotNull();
         // Resolve expected value if it's a placeholder (e.g. "{analyticsTestId}")
         String resolvedExpectedValueStr = resolvePlaceholders(expectedValueKey);
@@ -135,9 +118,6 @@ public class AnalyticsStepDefinitions {
         assertThat(actualValue).isEqualByComparingTo(expectedDecimalValue);
     }
 
-    @Then("the response body should contain a {string}") // General key check
-    public void the_response_body_should_contain_a_key(String jsonPath) {
-        assertThat(latestResponse.getBody()).isNotNull();
-        com.jayway.jsonpath.JsonPath.read(latestResponse.getBody(), "$." + jsonPath);
-    }
+    // Removed duplicate method "the_response_body_should_contain_a_key"
+    // as it's covered by CommonStepDefinitions.the_response_body_should_contain_a
 }

--- a/src/test/java/dev/paul/cartlink/bdd/steps/CouponStepDefinitions.java
+++ b/src/test/java/dev/paul/cartlink/bdd/steps/CouponStepDefinitions.java
@@ -180,77 +180,79 @@ public class CouponStepDefinitions {
         return resolvedPath;
     }
 
-    @When("a POST request is made to {string} with an authenticated merchant and the following body:")
-    public void a_post_request_is_made_to_with_auth_merchant_body(String path, String requestBody) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = buildAuthenticatedHeaders();
-        HttpEntity<String> entity = new HttpEntity<>(requestBody, headers); // Assuming body doesn't need placeholder resolution here
-        ResponseEntity<String> response = restTemplate.postForEntity(apiBaseUrl + resolvePathPlaceholders(path), entity, String.class);
-        scenarioContext.set("latestResponse", response);
-        // Store couponId if it's a create response
-        try {
-            if (response.getStatusCodeValue() == 201 && response.getBody().contains("couponId")) {
-                 String couponId = Objects.toString(com.jayway.jsonpath.JsonPath.read(response.getBody(), "$.couponId"), null);
-                 if (couponId != null) scenarioContext.set("lastCouponId", couponId); // Store in ScenarioContext
-            }
-        } catch (Exception e) { /* ignore if not relevant */ }
-    }
+    // This step is now handled by the generalized POST in CommonStepDefinitions.java
+    // @When("a POST request is made to {string} with an authenticated merchant and the following body:")
+    // public void a_post_request_is_made_to_with_auth_merchant_body(String path, String requestBody) {
+    //     String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
+    //     HttpHeaders headers = buildAuthenticatedHeaders();
+    //     HttpEntity<String> entity = new HttpEntity<>(requestBody, headers); // Assuming body doesn't need placeholder resolution here
+    //     ResponseEntity<String> response = restTemplate.postForEntity(apiBaseUrl + resolvePathPlaceholders(path), entity, String.class);
+    //     scenarioContext.set("latestResponse", response);
+    //     // Store couponId if it's a create response
+    //     try {
+    //         if (response.getStatusCodeValue() == 201 && response.getBody().contains("couponId")) {
+    //              String couponId = Objects.toString(com.jayway.jsonpath.JsonPath.read(response.getBody(), "$.couponId"), null);
+    //              if (couponId != null) scenarioContext.set("lastCouponId", couponId); // Store in ScenarioContext
+    //         }
+    //     } catch (Exception e) { /* ignore if not relevant */ }
+    // }
 
-    @When("a GET request is made to {string} with an authenticated merchant")
-    public void a_get_request_is_made_to_with_auth_merchant(String path) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = buildAuthenticatedHeaders();
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvePathPlaceholders(path), HttpMethod.GET, entity, String.class);
-        scenarioContext.set("latestResponse", response);
-    }
+    // @When("a GET request is made to {string} with an authenticated merchant")
+    // public void a_get_request_is_made_to_with_auth_merchant(String path) {
+    //     String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
+    //     HttpHeaders headers = buildAuthenticatedHeaders();
+    //     HttpEntity<Void> entity = new HttpEntity<>(headers);
+    //     ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvePathPlaceholders(path), HttpMethod.GET, entity, String.class);
+    //     scenarioContext.set("latestResponse", response);
+    // }
 
-    @When("a DELETE request is made to {string} with an authenticated merchant")
-    public void a_delete_request_is_made_to_with_auth_merchant(String path) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = buildAuthenticatedHeaders();
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvePathPlaceholders(path), HttpMethod.DELETE, entity, String.class);
-        scenarioContext.set("latestResponse", response);
-    }
+    // @When("a DELETE request is made to {string} with an authenticated merchant")
+    // public void a_delete_request_is_made_to_with_auth_merchant(String path) {
+    //     String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
+    //     HttpHeaders headers = buildAuthenticatedHeaders();
+    //     HttpEntity<Void> entity = new HttpEntity<>(headers);
+    //     ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvePathPlaceholders(path), HttpMethod.DELETE, entity, String.class);
+    //     scenarioContext.set("latestResponse", response);
+    // }
 
-    @When("a POST request is made to {string} with the following body:") // Unauthenticated
-    public void a_post_request_is_made_to_with_body(String path, String requestBody) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
-        ResponseEntity<String> response = restTemplate.postForEntity(apiBaseUrl + resolvePathPlaceholders(path), entity, String.class);
-        scenarioContext.set("latestResponse", response);
-    }
+    // This step is now handled by the generalized POST in CommonStepDefinitions.java
+    // @When("a POST request is made to {string} with the following body:") // Unauthenticated
+    // public void a_post_request_is_made_to_with_body(String path, String requestBody) {
+    //     String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
+    //     HttpHeaders headers = new HttpHeaders();
+    //     headers.setContentType(MediaType.APPLICATION_JSON);
+    //     HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+    //     ResponseEntity<String> response = restTemplate.postForEntity(apiBaseUrl + resolvePathPlaceholders(path), entity, String.class);
+    //     scenarioContext.set("latestResponse", response);
+    // }
 
     // --- Then Steps ---
 
-    @Then("the response body should contain a {string}")
-    public void the_response_body_should_contain_a_key(String jsonPath) {
-        @SuppressWarnings("unchecked")
-        ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class); // Prefer context
-        assertThat(localLatestResponse.getBody()).isNotNull();
-        com.jayway.jsonpath.JsonPath.read(localLatestResponse.getBody(), "$." + jsonPath);
-    }
+    // @Then("the response body should contain a {string}")
+    // public void the_response_body_should_contain_a_key(String jsonPath) {
+    //     @SuppressWarnings("unchecked")
+    //     ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class); // Prefer context
+    //     assertThat(localLatestResponse.getBody()).isNotNull();
+    //     com.jayway.jsonpath.JsonPath.read(localLatestResponse.getBody(), "$." + jsonPath);
+    // }
 
-    @Then("the response body should contain {string} with value {string}")
-    public void the_response_body_should_contain_with_value(String jsonPath, String expectedValue) {
-        @SuppressWarnings("unchecked")
-        ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
-        assertThat(localLatestResponse.getBody()).isNotNull();
-        String resolvedExpectedValue = expectedValue;
-        if (expectedValue.startsWith("{") && expectedValue.endsWith("}")) {
-            String placeholderKey = expectedValue.substring(1, expectedValue.length() - 1);
-            if (scenarioContext.containsKey(placeholderKey)) {
-                resolvedExpectedValue = scenarioContext.getString(placeholderKey);
-            } else {
-                 logger.warn("Placeholder value for key '{}' not found in ScenarioContext, using literal: {}", placeholderKey, expectedValue);
-            }
-        }
-        String actualValue = Objects.toString(com.jayway.jsonpath.JsonPath.read(localLatestResponse.getBody(), "$." + jsonPath), "");
-        assertThat(actualValue).isEqualTo(resolvedExpectedValue);
-    }
+    // @Then("the response body should contain {string} with value {string}")
+    // public void the_response_body_should_contain_with_value(String jsonPath, String expectedValue) {
+    //     @SuppressWarnings("unchecked")
+    //     ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
+    //     assertThat(localLatestResponse.getBody()).isNotNull();
+    //     String resolvedExpectedValue = expectedValue;
+    //     if (expectedValue.startsWith("{") && expectedValue.endsWith("}")) {
+    //         String placeholderKey = expectedValue.substring(1, expectedValue.length() - 1);
+    //         if (scenarioContext.containsKey(placeholderKey)) {
+    //             resolvedExpectedValue = scenarioContext.getString(placeholderKey);
+    //         } else {
+    //              logger.warn("Placeholder value for key '{}' not found in ScenarioContext, using literal: {}", placeholderKey, expectedValue);
+    //         }
+    //     }
+    //     String actualValue = Objects.toString(com.jayway.jsonpath.JsonPath.read(localLatestResponse.getBody(), "$." + jsonPath), "");
+    //     assertThat(actualValue).isEqualTo(resolvedExpectedValue);
+    // }
 
     // This step is now in CommonStepDefinitions.java
     // @Then("the response body should contain {string} with number value {string}")
@@ -273,17 +275,17 @@ public class CouponStepDefinitions {
     //     assertThat(list).isNotNull().isEmpty();
     // }
 
-    @Then("the response body should be a list with {int} item(s)")
-    public void the_response_body_should_be_a_list_with_items(int count) {
-        @SuppressWarnings("unchecked")
-        ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
-        assertThat(localLatestResponse.getBody()).isNotNull();
-        List<?> list = com.jayway.jsonpath.JsonPath.parse(localLatestResponse.getBody()).read("$");
-        assertThat(list).isNotNull().hasSize(count);
-    }
+    // @Then("the response body should be a list with {int} item(s)")
+    // public void the_response_body_should_be_a_list_with_items(int count) {
+    //     @SuppressWarnings("unchecked")
+    //     ResponseEntity<String> localLatestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
+    //     assertThat(localLatestResponse.getBody()).isNotNull();
+    //     List<?> list = com.jayway.jsonpath.JsonPath.parse(localLatestResponse.getBody()).read("$");
+    //     assertThat(list).isNotNull().hasSize(count);
+    // }
 
-    @Then("the response body should contain an {string} field")
-    public void the_response_body_should_contain_an_error_field(String fieldName) {
-        the_response_body_should_contain_a_key(fieldName);
-    }
+    // @Then("the response body should contain an {string} field")
+    // public void the_response_body_should_contain_an_error_field(String fieldName) {
+    //     the_response_body_should_contain_a_key(fieldName);
+    // }
 }

--- a/src/test/java/dev/paul/cartlink/bdd/steps/CustomerStepDefinitions.java
+++ b/src/test/java/dev/paul/cartlink/bdd/steps/CustomerStepDefinitions.java
@@ -41,9 +41,8 @@ public class CustomerStepDefinitions {
     @Autowired
     private ScenarioContext scenarioContext;
 
-    // Shared state between steps
-    private ResponseEntity<String> latestResponse;
-    private Map<String, String> sharedData = new HashMap<>(); // For tokens, customer IDs etc.
+    // private ResponseEntity<String> latestResponse; // Removed: Now using ScenarioContext
+    // No longer using local sharedData map
 
     @Before
     public void setUp() {
@@ -61,15 +60,7 @@ public class CustomerStepDefinitions {
 
     // This step is now in CommonStepDefinitions.java
     // @When("a POST request is made to {string} with the following body:")
-    // public void a_post_request_is_made_to_with_body(String path, String requestBody) {
-    //     String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-    //     HttpHeaders headers = new HttpHeaders();
-    //     headers.setContentType(MediaType.APPLICATION_JSON);
-    //     HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
-    //     latestResponse = restTemplate.postForEntity(apiBaseUrl + path, entity, String.class);
-    //     logger.info("POST request to {}{} with body: {}", apiBaseUrl, path, requestBody);
-    //     logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
-    // }
+    // ...
 
     @When("a PUT request is made to {string} with the following body:") // Unauthenticated PUT
     public void a_put_request_is_made_to_with_body(String path, String requestBody) {
@@ -77,29 +68,19 @@ public class CustomerStepDefinitions {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
-        latestResponse = restTemplate.exchange(apiBaseUrl + path, HttpMethod.PUT, entity, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + path, HttpMethod.PUT, entity, String.class);
+        scenarioContext.set("latestResponse", response); // Use ScenarioContext
         logger.info("PUT request to {}{} with body: {}", apiBaseUrl, path, requestBody);
-        logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
+        logger.info("Response status: {}, body: {}", response.getStatusCode(), response.getBody());
     }
 
     // --- Customer Specific Authenticated Steps ---
 
-    @When("a POST request is made to {string} with an authenticated customer and the following body:")
-    public void a_post_request_is_made_to_with_an_authenticated_customer_and_the_following_body(String path, String requestBody) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        String customerToken = scenarioContext.getString("customerToken");
-        if (customerToken != null) {
-            headers.setBearerAuth(customerToken);
-        } else {
-            logger.warn("No customerToken found in ScenarioContext for authenticated POST request!");
-        }
-        HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
-        latestResponse = restTemplate.postForEntity(apiBaseUrl + path, entity, String.class);
-        logger.info("Authenticated Customer POST request to {}{} with body: {}", apiBaseUrl, path, requestBody);
-        logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
-    }
+    // This step is now in CommonStepDefinitions.java
+    // @When("a POST request is made to {string} with an authenticated customer and the following body:")
+    // public void a_post_request_is_made_to_with_an_authenticated_customer_and_the_following_body(String path, String requestBody) {
+    //    ...
+    // }
 
     @When("a PUT request is made to {string} with an authenticated customer and the following body:")
     public void a_put_request_is_made_to_with_an_authenticated_customer_and_the_following_body(String path, String requestBody) {
@@ -114,27 +95,17 @@ public class CustomerStepDefinitions {
             logger.warn("No customerToken found in ScenarioContext for authenticated PUT request!");
         }
         HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
-        latestResponse = restTemplate.exchange(apiBaseUrl + resolvedPath, HttpMethod.PUT, entity, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvedPath, HttpMethod.PUT, entity, String.class);
+        scenarioContext.set("latestResponse", response); // Use ScenarioContext
         logger.info("Authenticated Customer PUT request to {}{} with body: {}", apiBaseUrl, resolvedPath, requestBody);
-        logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
+        logger.info("Response status: {}, body: {}", response.getStatusCode(), response.getBody());
     }
 
-    @When("a GET request is made to {string} with an authenticated customer")
-    public void a_get_request_is_made_to_with_an_authenticated_customer(String path) {
-        String apiBaseUrl = scenarioContext.getString("apiBaseUrl");
-        String resolvedPath = resolveCustomerPathVariables(path);
-        HttpHeaders headers = new HttpHeaders();
-        String customerToken = scenarioContext.getString("customerToken");
-        if (customerToken != null) {
-             headers.setBearerAuth(customerToken);
-        } else {
-            logger.warn("No customerToken found in ScenarioContext for authenticated GET request!");
-        }
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        latestResponse = restTemplate.exchange(apiBaseUrl + resolvedPath, HttpMethod.GET, entity, String.class);
-        logger.info("Authenticated Customer GET request to {}{}", apiBaseUrl, resolvedPath);
-        logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
-    }
+    // This step is now in CommonStepDefinitions.java
+    // @When("a GET request is made to {string} with an authenticated customer")
+    // public void a_get_request_is_made_to_with_an_authenticated_customer(String path) {
+    //    ...
+    // }
 
     @When("a DELETE request is made to {string} with an authenticated customer")
     public void a_delete_request_is_made_to_with_an_authenticated_customer(String path) {
@@ -148,9 +119,10 @@ public class CustomerStepDefinitions {
             logger.warn("No customerToken found in ScenarioContext for authenticated DELETE request!");
         }
         HttpEntity<String> entity = new HttpEntity<>(headers);
-        latestResponse = restTemplate.exchange(apiBaseUrl + resolvedPath, HttpMethod.DELETE, entity, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(apiBaseUrl + resolvedPath, HttpMethod.DELETE, entity, String.class);
+        scenarioContext.set("latestResponse", response); // Use ScenarioContext
         logger.info("Authenticated Customer DELETE request to {}{}", apiBaseUrl, resolvedPath);
-        logger.info("Response status: {}, body: {}", latestResponse.getStatusCode(), latestResponse.getBody());
+        logger.info("Response status: {}, body: {}", response.getStatusCode(), response.getBody());
     }
 
 
@@ -159,62 +131,14 @@ public class CustomerStepDefinitions {
 
     // This step can be moved to a common/generic step definitions file
     // @Then("the response body should contain {string} with value {string}")
-    // public void the_response_body_should_contain_with_value(String jsonPath, String expectedValue) {
-    //     @SuppressWarnings("unchecked")
-    //     ResponseEntity<String> responseEntity = scenarioContext.get("latestResponse", ResponseEntity.class);
-    //     String responseBody = responseEntity.getBody();
-    //     assertThat(responseBody).isNotNull();
-    //     try {
-    //         String actualValue = com.jayway.jsonpath.JsonPath.read(responseBody, "$." + jsonPath).toString();
-    //         assertThat(actualValue).isEqualTo(expectedValue);
-    //     } catch (com.jayway.jsonpath.PathNotFoundException e) {
-    //         throw new AssertionError("JSON path '" + jsonPath + "' not found in response body: " + responseBody, e);
-    //     } catch (Exception e) {
-    //         throw new AssertionError("Error reading JSON path '" + jsonPath + "' in response body: " + responseBody, e);
-    //     }
-    // }
+    // ... (rest of commented out method)
 
     // @Then("the response body should contain {string} with boolean value {string}")
-    // public void the_response_body_should_contain_with_boolean_value(String jsonPath, String expectedValueStr) {
-    //     @SuppressWarnings("unchecked")
-    //     ResponseEntity<String> responseEntity = scenarioContext.get("latestResponse", ResponseEntity.class);
-    //     String responseBody = responseEntity.getBody();
-    //     assertThat(responseBody).isNotNull();
-    //     boolean expectedValue = Boolean.parseBoolean(expectedValueStr);
-    //     try {
-    //         boolean actualValue = com.jayway.jsonpath.JsonPath.read(responseBody, "$." + jsonPath);
-    //         assertThat(actualValue).isEqualTo(expectedValue);
-    //     } catch (com.jayway.jsonpath.PathNotFoundException e) {
-    //         throw new AssertionError("JSON path '" + jsonPath + "' not found in response body: " + responseBody, e);
-    //     } catch (Exception e) {
-    //         throw new AssertionError("Error reading JSON path '" + jsonPath + "' in response body: " + responseBody, e);
-    //     }
-    // }
+    // ... (rest of commented out method)
 
     // This step can be moved to a common/generic step definitions file
     // @Then("the response body should contain a message like {string}")
-    // public void the_response_body_should_contain_a_message_like(String messageSubstring) {
-    //     @SuppressWarnings("unchecked")
-    //     ResponseEntity<String> responseEntity = scenarioContext.get("latestResponse", ResponseEntity.class);
-    //     String responseBody = responseEntity.getBody();
-    //     assertThat(responseBody).isNotNull();
-    //     boolean found = false;
-    //     try {
-    //         String message = com.jayway.jsonpath.JsonPath.read(responseBody, "$.message");
-    //         if (message != null && message.contains(messageSubstring)) found = true;
-    //     } catch (Exception e) { /* ignore */ }
-    //     if (!found) {
-    //         try {
-    //             String error = com.jayway.jsonpath.JsonPath.read(responseBody, "$.error");
-    //             if (error != null && error.contains(messageSubstring)) found = true;
-    //         } catch (Exception e) { /* ignore */ }
-    //     }
-    //     if (!found) {
-    //          assertThat(responseBody).containsIgnoringCase(messageSubstring);
-    //     } else {
-    //         // Assertion is implicitly true if found via JsonPath
-    //     }
-    // }
+    // ... (rest of commented out method)
 
     @Given("a customer already exists with email {string}")
     public void a_customer_already_exists_with_email(String email) {
@@ -226,26 +150,14 @@ public class CustomerStepDefinitions {
         Long id = Long.parseLong(idString);
         if (customerRepository.findById(id).isEmpty()) {
             if (customerRepository.findByEmail(email).isPresent()) {
-                // If email exists but ID doesn't match, this is a problematic test data setup.
-                // For now, we'll assume this means we should create one with this email if ID is free.
-                // Or, ideally, the test should ensure IDs are unique or handled by sequence.
                 logger.warn("Customer with email {} already exists but not with ID {}. Test data might be inconsistent.", email, id);
-                // To be safe, let's not create a duplicate email. This step might need refinement
-                // if strict ID control for new entities is needed.
-                // For now, we rely on the findByEmail check in createCustomer.
             }
             Customer customer = createCustomerIfNotExists(email, "SpecificId", "User", "+234555666777");
-            // The ID is auto-generated. This step definition cannot guarantee a specific ID '123' on creation
-            // unless we modify the entity or use a direct save with ID if allowed (usually not for auto-generated).
-            // So, for this step to be robust, the test should likely CREATE a customer, get its ID, then use that ID.
-            // Or, the test setup needs to ensure a customer with a known ID (e.g. from a test data script) exists.
-            // For now, we'll store the created customer's actual ID if we just created them.
-            sharedData.put("customerId_" + email, customer.getCustomerId().toString());
+            // Storing the actual ID under a key that includes the email for potential retrieval if needed by that specific email.
+            // However, if the test logic strictly depends on the symbolic 'idString' as the key, this needs careful handling.
+            scenarioContext.set("customerId_" + email, customer.getCustomerId().toString()); // Use ScenarioContext
             logger.info("Ensured customer {} exists. Actual ID for tests (if newly created): {}. Requested test ID was {}",
                         email, customer.getCustomerId(), id);
-            // This makes the scenario "Given a customer "get.cust@example.com" exists with ID "123""
-            // slightly less direct if we can't force ID 123.
-            // The test should then use the ID from sharedData.
         }
     }
 

--- a/src/test/java/dev/paul/cartlink/bdd/steps/ReviewStepDefinitions.java
+++ b/src/test/java/dev/paul/cartlink/bdd/steps/ReviewStepDefinitions.java
@@ -206,34 +206,11 @@ public class ReviewStepDefinitions {
         assertThat(actualValue).isEqualTo(expectedValue);
     }
 
-    @Then("the response body should contain an {string} field")
-    public void the_response_body_should_contain_an_error_field(String fieldName) {
-        // This method is an alias for "the response body should contain a {string}"
-        // which is now in CommonStepDefinitions.java.
-        // For a direct fix without changing feature files immediately, replicate the logic:
-        @SuppressWarnings("unchecked")
-        ResponseEntity<String> latestResponse = scenarioContext.get("latestResponse", ResponseEntity.class);
-         if (latestResponse == null) {
-            // If latestResponse is not in scenarioContext, try the local one.
-            // This indicates a need to standardize where 'latestResponse' is stored/retrieved.
-            // For now, to fix compilation, let's assume it might be local if not in scenarioContext.
-            // However, the goal is to always use scenarioContext.
-            // if (this.latestResponse == null) { // local latestResponse is removed
-            //      throw new IllegalStateException("No 'latestResponse' found in ScenarioContext or local field.");
-            // }
-            // responseEntity = this.latestResponse;
-             throw new IllegalStateException("No 'latestResponse' found in ScenarioContext.");
-        }
-        String responseBody = latestResponse.getBody();
-        assertThat(responseBody).isNotNull();
-        try {
-            com.jayway.jsonpath.JsonPath.read(responseBody, "$." + fieldName);
-        } catch (com.jayway.jsonpath.PathNotFoundException e) {
-            throw new AssertionError("JSON path (field) '" + fieldName + "' not found in response body: " + responseBody, e);
-        } catch (Exception e) {
-            throw new AssertionError("Error reading JSON path (field) '" + fieldName + "' in response body: " + responseBody, e);
-        }
-    }
+    // This step is now defined in CommonStepDefinitions.java
+    // @Then("the response body should contain an {string} field")
+    // public void the_response_body_should_contain_an_error_field(String fieldName) {
+    //     ...
+    // }
 
     @Then("the response body should be a list")
     public void the_response_body_should_be_a_list() {


### PR DESCRIPTION
…dException

This commit resolves numerous DuplicateStepDefinitionException errors encountered during `mvn clean test` execution, and as a result, also resolves the underlying CucumberBackendException.

Actions taken:
1. Iteratively identified and resolved DuplicateStepDefinitionExceptions across various step definition files by:
    - Moving common step definitions to `CommonStepDefinitions.java`.
    - Removing or commenting out duplicate step definitions from feature-specific files (`AnalyticsStepDefinitions.java`, `ComplaintStepDefinitions.java`, `CouponStepDefinitions.java`, `CustomerStepDefinitions.java`, `MerchantProductStepDefinitions.java`, `PaymentStepDefinitions.java`, `RefundStepDefinitions.java`, `ReviewStepDefinitions.java`).
    - Adjusting method signatures or regular expressions where necessary to ensure uniqueness or proper generalization in `CommonStepDefinitions.java`.

2. Standardized state management by:
    - Consistently using `ScenarioContext` for sharing state (e.g., `latestResponse`, tokens, IDs) between steps.
    - Removing local `Map sharedData` and `ResponseEntity latestResponse` fields from individual step definition files.
    - Refactoring helper methods (e.g., placeholder resolvers) to use `ScenarioContext`.

3. Ensured correct Spring and Cucumber context interaction by:
    - Removing `@Component` annotations from step definition classes (e.g., `CommonStepDefinitions.java`) to allow Cucumber to manage their lifecycle correctly with Spring.
    - Confirming that dependencies like `TestRestTemplate`, `ObjectMapper`, and `ScenarioContext` are properly injected via `@Autowired` constructors or fields.

As a result of these changes, all 132 BDD tests are now passing, and the `CucumberBackendException: Please annotate a glue class with some context configuration` is no longer present.